### PR TITLE
adding enum for more readable code

### DIFF
--- a/Calculator1.xcodeproj/project.pbxproj
+++ b/Calculator1.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5F4DB337274521CA00CBE3E2 /* OperationType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F4DB336274521CA00CBE3E2 /* OperationType.swift */; };
 		D0A65BD1273D5B9000B501BC /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A65BD0273D5B9000B501BC /* AppDelegate.swift */; };
 		D0A65BD3273D5B9000B501BC /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A65BD2273D5B9000B501BC /* SceneDelegate.swift */; };
 		D0A65BD5273D5B9000B501BC /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A65BD4273D5B9000B501BC /* ViewController.swift */; };
@@ -16,6 +17,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		5F4DB336274521CA00CBE3E2 /* OperationType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationType.swift; sourceTree = "<group>"; };
 		D0A65BCD273D5B9000B501BC /* Calculator1.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Calculator1.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0A65BD0273D5B9000B501BC /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		D0A65BD2273D5B9000B501BC /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -59,6 +61,7 @@
 				D0A65BD0273D5B9000B501BC /* AppDelegate.swift */,
 				D0A65BD2273D5B9000B501BC /* SceneDelegate.swift */,
 				D0A65BD4273D5B9000B501BC /* ViewController.swift */,
+				5F4DB336274521CA00CBE3E2 /* OperationType.swift */,
 				D0A65BD6273D5B9000B501BC /* Main.storyboard */,
 				D0A65BD9273D5B9200B501BC /* Assets.xcassets */,
 				D0A65BDB273D5B9200B501BC /* LaunchScreen.storyboard */,
@@ -139,6 +142,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D0A65BD5273D5B9000B501BC /* ViewController.swift in Sources */,
+				5F4DB337274521CA00CBE3E2 /* OperationType.swift in Sources */,
 				D0A65BD1273D5B9000B501BC /* AppDelegate.swift in Sources */,
 				D0A65BD3273D5B9000B501BC /* SceneDelegate.swift in Sources */,
 			);
@@ -289,6 +293,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N7AGGR3TBG;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Calculator1/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -318,6 +323,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = N7AGGR3TBG;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Calculator1/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Calculator1/OperationType.swift
+++ b/Calculator1/OperationType.swift
@@ -1,0 +1,15 @@
+//
+//  OperationType.swift
+//  Calculator1
+//
+//  Created by Иван Викторович on 17.11.2021.
+//
+
+import Foundation
+
+enum OperationType: Int {
+    case plus = 10
+    case minus = 11
+    case multiply = 12
+    case definioton = 13
+}

--- a/Calculator1/ViewController.swift
+++ b/Calculator1/ViewController.swift
@@ -14,7 +14,7 @@ class ViewController: UIViewController {
     var dotIsSetted = false
     var firstNum: Double = 0
     var secondNum: Double = 0
-    var operation = 0
+    var operation: OperationType?
     var currentInput: Double {
         get {
             return Double(resultLabel.text!)!
@@ -43,7 +43,7 @@ class ViewController: UIViewController {
     }
     // Created the function for action button (plus, minus, definioton, multiply)
     @IBAction func actionButton(_ sender: UIButton) {
-        operation = sender.tag
+        operation = OperationType(rawValue: sender.tag)
         firstNum = currentInput
         stillTyping = false
         dotIsSetted = false
@@ -61,13 +61,13 @@ class ViewController: UIViewController {
         dotIsSetted = false
         
         switch operation {
-        case 10:
+        case .plus:
             actions {$0 + $1}
-        case 11:
+        case .minus:
             actions {$0 - $1}
-        case 12:
+        case .multiply:
             actions {$0 * $1}
-        case 13:
+        case .definioton:
             actions {$0 / $1}
         default: break
         }


### PR DESCRIPTION
Не понятно что за операции, если они обозначаются с помощью `Int`. Для большего понимания и читабельности кода такие шутки можно заменить на `enum`.
Я создал новый файл с названием `OperationType` который содержит в себе `enum OperationType`. Подключил enum к типу данных `Int` и присвоил каждому кейсу необходимый `Int` в соотвествии с `tag`-ом кнопки которая вызывает этот action. 
Теперь перечисление вида
```
switch operation {
    case 10:
        actions {$0 + $1}
    case 11:
        actions {$0 - $1}
    case 12:
        actions {$0 * $1}
    case 13:
        actions {$0 / $1}
    default: break
}
```

можно заменить на более понятное и лаконичное
```
switch operation {
    case .plus:
        actions {$0 + $1}
    case .minus:
        actions {$0 - $1}
    case .multiply:
        actions {$0 * $1}
    case .definioton:
        actions {$0 / $1}
    default: break
}
```